### PR TITLE
New finish flags

### DIFF
--- a/cmd-feature
+++ b/cmd-feature
@@ -257,6 +257,8 @@ r,[no]rebase           Rebase before merging
 p,[no]preserve-merges  Preserve merges while rebasing
 S,[no]squash           Squash feature during merges
 no-ff!                 Never fast-forward during merges
+aux-branch-name        Prompt for auxiliary branch names
+pr-title			   Prompt for PR titles
 --
 k,[no]keep             Always true -- Keep branch after performing finish
 keepremote!        	   Always true -- Keep the remote branch
@@ -275,6 +277,8 @@ D,[no]force_delete     Unused -- Force delete feature branch after finish
 	DEFINE_boolean 'force_delete' false "force delete feature branch after finish" D
 	DEFINE_boolean 'squash' false "squash feature during merge" S
 	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
+	DEFINE_boolean 'aux-branch-name' false "prompt for auxiliary branch names"
+	DEFINE_boolean 'pr-title' false "prompt for PR titles"
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "feature.finish.fetch"             "fetch"
@@ -287,6 +291,8 @@ D,[no]force_delete     Unused -- Force delete feature branch after finish
 	gitflow_override_flag_boolean   "feature.finish.force-delete"      "force_delete"
 	gitflow_override_flag_boolean   "feature.finish.squash"            "squash"
 	gitflow_override_flag_boolean   "feature.finish.no-ff"             "no_ff"
+	gitflow_override_flag_boolean   "feature.finish.aux-branch-name"   "aux_branch_name"
+	gitflow_override_flag_boolean   "feature.finish.pr-title"          "pr_title"
 
 	# Parse arguments
 	parse_args "$@"
@@ -429,22 +435,22 @@ helper_finish_merges(){
 		fi
 
 		local base aux_branch aux_branch_prefix aux_branch_name head with_pr
-		local issue_number return_code pr_body tmp_file
+		local issue_number return_code pr_title pr_body tmp_file
 
 		# Get properties from config
 		base=$(trim_line_quotes $(json_get_key "$step" '."base"'))
 		if [ -z "$base" ] || [ "$base" = "null" ]; then
-			die "Missing aux-branch-prefix property in finish-step $step_count"
+			die "Missing base property in finish-step $step_count"
 		fi
 
 		aux_branch=$(json_get_key "$step" '."aux-branch"')
 		if [ -z "$aux_branch" ] || [ "$aux_branch" = "null" ]; then
-			die "Missing aux-branch-prefix property in finish-step $step_count"
+			die "Missing aux-branch property in finish-step $step_count"
 		fi
 
 		with_pr=$(json_get_key "$step" '."with-pr"')
 		if [ -z "$with_pr" ] || [ "$with_pr" = "null" ]; then
-			die "Missing aux-branch-prefix property in finish-step $step_count"
+			die "Missing with-pr property in finish-step $step_count"
 		fi
 
 		print_arr+=("---------------- $base ----------------")
@@ -512,13 +518,21 @@ helper_finish_merges(){
 				labels="[]"
 			fi
 			
+			# If needed, prompt for PR title
+			pr_title="$head"
+			if flag pr_title; then
+				echo
+				pr_title=$(read_input "Title for the PR from $head to $base" "$pr_title")
+				echo
+			fi
+
 			# Open editor to write PR body
 			pr_body="$last_pr_body"
-			pr_body=$(get_input_editor "$pr_body" "pr_from_${head}_to_${base}")
+			pr_body=$(get_input_editor "$pr_body" "$pr_title")
 			last_pr_body="$pr_body"
 
-			# Create PR from $head branch to $base branch if not open (label: $base)
-			issue_number=$(github_create_pr "$head" "$base" "$labels" "$pr_body")
+			# Create PR from $head branch to $base branch if not open
+			issue_number=$(github_create_pr "$head" "$base" "$labels" "$pr_title" "$pr_body")
 			return_code="$?"
 			if [ "$return_code" -eq 0 ]; then
 				print_arr+=("- Created PR from $head to $base: https://github.com/$GIT_USERNAME/$GIT_REPOSITORY/pull/$issue_number")

--- a/cmd-feature
+++ b/cmd-feature
@@ -302,10 +302,18 @@ D,[no]force_delete     Unused -- Force delete feature branch after finish
 		gitflow_set_name_as_current_branch
 	fi
 	require_feature_name_or_aux
+	local is_aux_branch="$?"
 
 	# Keeping both branches implies the --keep flag to be true.
 	if flag keepremote && flag keeplocal; then
 		FLAGS_keep=$FLAGS_TRUE
+	fi
+
+	# If aux branch name could have changed and we are in an aux branch
+	# Then we need the user to input the actual branch name
+	if flag aux_branch_name && [ "$is_aux_branch" -eq 1 ]; then
+		gitflow_set_name $(read_input "Feature branch name: " "$BRANCH")
+		echo
 	fi
 
 	# Sanity checks
@@ -415,6 +423,8 @@ D,[no]force_delete     Unused -- Force delete feature branch after finish
 #			 Helps when solving conflicts, to resume execution
 #
 helper_finish_merges(){
+	local INPUT_HELPER_FILENAME="$DOT_GIT_DIR/.gitflow/INPUT_$BRANCH"
+
 	local keepmsg last_pr_body print_arr all_steps
 	local step_num stage_num step_count
 
@@ -471,7 +481,19 @@ helper_finish_merges(){
 			if [ -z "$aux_branch_prefix" ] || [ "$aux_branch_prefix" = "null" ]; then
 				die "Missing aux-branch-prefix property in finish-step $step_count"
 			fi
+
+			# If needed, prompt for aux branch name
 			aux_branch_name="$aux_branch_prefix$BRANCH"
+			if flag aux_branch_name; then
+				if [ -f "$INPUT_HELPER_FILENAME" ]; then
+					aux_branch_name=$(cat "$INPUT_HELPER_FILENAME")
+				else
+					echo
+					aux_branch_name="$aux_branch_name$(read_input "Name for aux branch to $base: $aux_branch_name")"
+					echo
+					echo "$aux_branch_name" > "$INPUT_HELPER_FILENAME"
+				fi
+			fi
 
 			head="$aux_branch_name"
 
@@ -522,7 +544,7 @@ helper_finish_merges(){
 			pr_title="$head"
 			if flag pr_title; then
 				echo
-				pr_title=$(read_input "Title for the PR from $head to $base" "$pr_title")
+				pr_title=$(read_input "Title for the PR from $head to $base: " "$pr_title")
 				echo
 			fi
 
@@ -558,6 +580,9 @@ helper_finish_merges(){
 		# Next steps should be done entirely
 		stage_num=0
 		print_arr+=("")
+
+		# Delete input files if exist
+		rm -f "$INPUT_HELPER_FILENAME"
 	done
 	print_arr+=("--------------------------------------------")
 

--- a/common
+++ b/common
@@ -1172,6 +1172,7 @@ github_list_all_pr() {
 # $1 head 	- Head branch to merge from
 # $2 base 	- Base branch to merge to
 # $3 labels - Labels for the PR (optional)
+# $4 title 	- Title of the PR (optional)
 # $4 body 	- Body of the PR (optional)
 #
 # Title will be set to head
@@ -1180,21 +1181,23 @@ github_list_all_pr() {
 # Returns 0 if OK, 1 if error, 2 if unauthorized
 #
 github_create_pr() {
-	local head base body response issue_number req_body
+	local head base labels title body response issue_number req_body
 
 	head="$1"
 	base="$2"
 	labels="$3"
-	body="$4"
+	title="$4"
+	body="$5"
 	
 	[ -n "$1" ] || die "Missing head"
 	[ -n "$2" ] || die "Missing base"
 	[ -n "$3" ] || labels="[]"
-	[ -n "$4" ] || body=""
+	[ -n "$4" ] || title="$head"
+	[ -n "$5" ] || body=""
 
-	body=$(string_to_json "$4") # Already includes starting and ending " "
+	body=$(string_to_json "$body") # Already includes starting and ending " "
 
-	req_body="{\"title\":\"$head\",\"base\":\"$base\", \"head\":\"$GIT_USERNAME:$head\", \"body\":$body}"
+	req_body="{\"title\":\"$title\",\"base\":\"$base\", \"head\":\"$GIT_USERNAME:$head\", \"body\":$body}"
 	response=$(github_api_post "/repos/$GIT_USERNAME/$GIT_REPOSITORY/pulls" "$req_body")
 
 	# Adding label to PR

--- a/common
+++ b/common
@@ -1198,7 +1198,7 @@ github_list_all_pr() {
 # $2 base 	- Base branch to merge to
 # $3 labels - Labels for the PR (optional)
 # $4 title 	- Title of the PR (optional)
-# $4 body 	- Body of the PR (optional)
+# $5 body 	- Body of the PR (optional)
 #
 # Title will be set to head
 #
@@ -1419,7 +1419,7 @@ get_jira_url() {
 # $1 prompt - Prompt message before input (no spaces or : will be added to it)
 # $2 default - Initial value to use as input (defaults to '')
 #
-# Returns input text (or default if provided)
+# Returns input text
 #
 read_input() {
 	local prompt default value

--- a/common
+++ b/common
@@ -375,6 +375,9 @@ gitflow_load_settings() {
 	# Neither usernames nor repositories can have /
 	export GIT_USERNAME=$(cut -d'/' -f1 <<< "$AUX_VARIABLE")
 	export GIT_REPOSITORY=$(cut -d'/' -f2- <<< "${AUX_VARIABLE%.git}")
+
+	# Create auxiliary directory for temporary files if not exists
+	mkdir -p "$DOT_GIT_DIR/.gitflow"
 }
 
 #
@@ -628,9 +631,23 @@ gitflow_require_base_arg() {
 	fi
 }
 
-gitflow_set_name_as_current_branch() {
-	BRANCH=$(git_current_branch)
+#
+# Set branch name variables
+# 
+# $1 branch_name - Branch to merge into other branch
+#
+gitflow_set_name() {
+	local branch_name
+
+	branch_name="$1"
+	[ -n "$1" ] || die "Missing branch name"
+
+	BRANCH="$branch_name"
 	NAME=${BRANCH}
+}
+
+gitflow_set_name_as_current_branch() {
+	gitflow_set_name $(git_current_branch)
 }
 
 gitflow_use_current_branch_name() {
@@ -687,6 +704,9 @@ gitflow_use_current_branch_name_from_aux() {
 	exit 1
 }
 
+#
+# Returns 0 if feature branch, 1 if aux branch
+#
 require_feature_name_or_aux() {
 	local branch_name root_branch 
 	local all_steps branch_prefixes aux_branch aux_branch_prefix
@@ -716,7 +736,7 @@ require_feature_name_or_aux() {
 				if startswith "$root_branch" "$HU_PREFIX"; then
 					BRANCH=$root_branch
 					NAME=${BRANCH}
-					return 0
+					return 1
 				fi
 			fi
 		done
@@ -986,7 +1006,6 @@ gitflow_merge_branch_to_base() {
 		# Oops.. we have a merge conflict!
 		# Write the given $branch and $base to a temporary file as we will
 		# be needing it later.
-		mkdir -p "$DOT_GIT_DIR/.gitflow"
 		echo "$branch\\$base\\$step_num\\$stage_num\\$CONFIG_SHA_SUM" > "$DOT_GIT_DIR/.gitflow/MERGE_BASE_$feature_name"
 		echo
 		echo "Summary of completed actions:"
@@ -1391,8 +1410,8 @@ get_jira_url() {
 #
 # Read user input
 #
-# $1 prompt - Prompt message before input (no : or default needed)
-# $2 default - Value to use if no value is provided (defaults to '')
+# $1 prompt - Prompt message before input (no spaces or : will be added to it)
+# $2 default - Initial value to use as input (defaults to '')
 #
 # Returns input text (or default if provided)
 #
@@ -1405,13 +1424,7 @@ read_input() {
 	[ -n "$1" ] || die "Missing prompt message"
 	[ -n "$2" ] || default=""
 
-	if [ -n "$default" ]; then
-		prompt="$prompt [$default]"
-	fi
-
-	read -p "$prompt: " value
-	value=${value:-$default}
-
+	read -p "$prompt" -ei "$default" value
 	echo "$value"
 }
 

--- a/common
+++ b/common
@@ -1386,6 +1386,33 @@ get_jira_url() {
 }
 
 #
+# Read user input
+#
+# $1 prompt - Prompt message before input (no : or default needed)
+# $2 default - Value to use if no value is provided (defaults to '')
+#
+# Returns input text (or default if provided)
+#
+read_input() {
+	local prompt default value
+
+	prompt="$1"
+	default="$2"
+	
+	[ -n "$1" ] || die "Missing prompt message"
+	[ -n "$2" ] || default=""
+
+	if [ -n "$default" ]; then
+		prompt="$prompt [$default]"
+	fi
+
+	read -p "$prompt: " value
+	value=${value:-$default}
+
+	echo "$value"
+}
+
+#
 # run_filter_hook
 #
 # Looks for a Git hook script called as defined by the first variable

--- a/common
+++ b/common
@@ -151,6 +151,12 @@ git_is_clean_working_tree() {
 	# Check for Uncommited changes
 	git diff-index --cached --quiet --ignore-submodules HEAD -- || return 2
 
+	# Check for Merge in progress. 
+	# Don't know why sometimes there are no uncommited changes and all conflicts are fixed. 
+	# But you are still merging, so this would be needed.
+	# Won't change it because it could be breaking more than it solves
+	# git merge HEAD &> /dev/null || return 3
+
 	return 0
 }
 
@@ -1022,7 +1028,7 @@ gitflow_merge_branch_to_base() {
 		echo "    git commit"
 		echo
 		echo "You can then complete the finish by running it again:"
-		echo "    gitflow feature finish $feature_name"
+		echo "    $EXECUTED_CMD"
 		echo
 		echo "Alternatively, you can cancel your merge by running"
 		echo "    git merge --abort"

--- a/config.json
+++ b/config.json
@@ -16,7 +16,9 @@
             "preserve-merges": false,
             "push": false,
             "squash": false,
-            "no-ff!": false
+            "no-ff!": false,
+            "aux-branch-name": false,
+            "pr-title": false
         },
         "rebase": {
             "interactive": false,

--- a/gitflow
+++ b/gitflow
@@ -165,6 +165,7 @@ main() {
 	fi
 	if [ $SUBACTION != 'default' ]; then
 		FLAGS_PARENT="./gitflow $SUBCOMMAND $SUBACTION"
+		EXECUTED_CMD="gitflow $SUBCOMMAND ${SUBACTION}$((($#)) && printf ' %q' "$@")"
 	fi
 
 	cmd_$SUBACTION "$@" "${_short_branch_name}"


### PR DESCRIPTION
Added the following flags to finish command
- `--aux-branch-name` will allow the user to modify auxiliary branch names (adding suffixes). This can be useful when an auxiliary branch is so old that merging into it will just cause trouble (aka merge conflicts)
- `--pr-title` will allow the user to modify the title of the PRs instead of using the default one (head branch name)